### PR TITLE
Add map_all and flat_map_all for combining multiple Results

### DIFF
--- a/src/Result/functions.php
+++ b/src/Result/functions.php
@@ -91,6 +91,50 @@ function transpose(Result $result): Option
 }
 
 /**
+ * Applies a callback to the values of multiple `Result`s if all are `Ok`.
+ *
+ * Returns the first `Err` encountered, or `Ok` wrapping the callback's return value.
+ *
+ * @template E
+ * @param  Result<covariant mixed, covariant E> ...$results
+ * @return Result<mixed, E>
+ */
+function map_all(Closure $fn, Result ...$results): Result
+{
+    $values = [];
+    foreach ($results as $result) {
+        if ($result->isErr()) {
+            return $result;
+        }
+        $values[] = $result->unwrap();
+    }
+
+    return ok($fn(...$values));
+}
+
+/**
+ * Applies a `Result`-returning callback to the values of multiple `Result`s if all are `Ok`.
+ *
+ * Returns the first `Err` encountered, or the `Result` returned by the callback.
+ *
+ * @template E
+ * @param  Result<covariant mixed, covariant E> ...$results
+ * @return Result<mixed, E>
+ */
+function flat_map_all(Closure $fn, Result ...$results): Result
+{
+    $values = [];
+    foreach ($results as $result) {
+        if ($result->isErr()) {
+            return $result;
+        }
+        $values[] = $result->unwrap();
+    }
+
+    return $fn(...$values);
+}
+
+/**
  * @template T
  * @template E
  * @param  Result<covariant T, covariant E> ...$results

--- a/tests/Unit/Result/FlatMapAllTest.php
+++ b/tests/Unit/Result/FlatMapAllTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EndouMame\PhpMonad\Tests\Unit\Result;
+
+use EndouMame\PhpMonad\Result;
+use EndouMame\PhpMonad\Tests\Assert;
+use EndouMame\PhpMonad\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+
+#[TestDox('Result - flat_map_all関数のテスト')]
+#[CoversClass(Result::class)]
+final class FlatMapAllTest extends TestCase
+{
+    #[Test]
+    #[TestDox('すべてがOkでコールバックがOkを返す場合')]
+    public function flatMapAllAllOkReturnsOk(): void
+    {
+        $result = Result\flat_map_all(
+            static fn (int $a, int $b): Result => Result\ok($a + $b),
+            Result\ok(1),
+            Result\ok(2),
+        );
+
+        Assert::assertTrue($result->isOk());
+        Assert::assertSame(3, $result->unwrap());
+    }
+
+    #[Test]
+    #[TestDox('すべてがOkでコールバックがErrを返す場合')]
+    public function flatMapAllAllOkReturnsErr(): void
+    {
+        $result = Result\flat_map_all(
+            static fn (int $a, int $b): Result => Result\err('callback error'),
+            Result\ok(1),
+            Result\ok(2),
+        );
+
+        Assert::assertTrue($result->isErr());
+        Assert::assertSame('callback error', $result->unwrapErr());
+    }
+
+    #[Test]
+    #[TestDox('Errが含まれる場合は最初のErrを返す')]
+    public function flatMapAllWithErr(): void
+    {
+        $result = Result\flat_map_all(
+            static fn (int $a, int $b): Result => Result\ok($a + $b),
+            Result\ok(1),
+            Result\err('error1'),
+            Result\err('error2'),
+        );
+
+        Assert::assertTrue($result->isErr());
+        Assert::assertSame('error1', $result->unwrapErr());
+    }
+
+    #[Test]
+    #[TestDox('単一のOkでも動作する')]
+    public function flatMapAllSingleOk(): void
+    {
+        $result = Result\flat_map_all(
+            static fn (int $a): Result => Result\ok("value: {$a}"),
+            Result\ok(42),
+        );
+
+        Assert::assertTrue($result->isOk());
+        Assert::assertSame('value: 42', $result->unwrap());
+    }
+
+    #[Test]
+    #[TestDox('単一のErrでも動作する')]
+    public function flatMapAllSingleErr(): void
+    {
+        $result = Result\flat_map_all(
+            static fn (int $a): Result => Result\ok("value: {$a}"),
+            Result\err('error'),
+        );
+
+        Assert::assertTrue($result->isErr());
+        Assert::assertSame('error', $result->unwrapErr());
+    }
+}

--- a/tests/Unit/Result/MapAllTest.php
+++ b/tests/Unit/Result/MapAllTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EndouMame\PhpMonad\Tests\Unit\Result;
+
+use EndouMame\PhpMonad\Result;
+use EndouMame\PhpMonad\Tests\Assert;
+use EndouMame\PhpMonad\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+
+#[TestDox('Result - map_all関数のテスト')]
+#[CoversClass(Result::class)]
+final class MapAllTest extends TestCase
+{
+    #[Test]
+    #[TestDox('すべてがOkの場合はコールバックの結果をOkで返す')]
+    public function mapAllAllOk(): void
+    {
+        $result = Result\map_all(
+            static fn (int $a, int $b, int $c): int => $a + $b + $c,
+            Result\ok(1),
+            Result\ok(2),
+            Result\ok(3),
+        );
+
+        Assert::assertTrue($result->isOk());
+        Assert::assertSame(6, $result->unwrap());
+    }
+
+    #[Test]
+    #[TestDox('Errが含まれる場合は最初のErrを返す')]
+    public function mapAllWithErr(): void
+    {
+        $result = Result\map_all(
+            static fn (int $a, int $b): int => $a + $b,
+            Result\ok(1),
+            Result\err('error1'),
+            Result\err('error2'),
+        );
+
+        Assert::assertTrue($result->isErr());
+        Assert::assertSame('error1', $result->unwrapErr());
+    }
+
+    #[Test]
+    #[TestDox('単一のOkでも動作する')]
+    public function mapAllSingleOk(): void
+    {
+        $result = Result\map_all(
+            static fn (int $a): string => "value: {$a}",
+            Result\ok(42),
+        );
+
+        Assert::assertTrue($result->isOk());
+        Assert::assertSame('value: 42', $result->unwrap());
+    }
+
+    #[Test]
+    #[TestDox('単一のErrでも動作する')]
+    public function mapAllSingleErr(): void
+    {
+        $result = Result\map_all(
+            static fn (int $a): string => "value: {$a}",
+            Result\err('error'),
+        );
+
+        Assert::assertTrue($result->isErr());
+        Assert::assertSame('error', $result->unwrapErr());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Result\map_all()` function that applies a callback to values of multiple `Result`s when all are `Ok`, wrapping the return value in `Ok`. Returns the first `Err` encountered otherwise.
- Add `Result\flat_map_all()` function that does the same but expects the callback to return a `Result` directly (no automatic `Ok` wrapping).
- Add comprehensive tests for both functions covering all-Ok, mixed Ok/Err, single Ok, and single Err cases.

These functions implement the Applicative Functor pattern, enabling flat composition of independent `Result` values without nested `andThen` calls.

## Test plan

- [x] All 428 existing tests pass
- [x] 9 new tests pass (4 for `map_all`, 5 for `flat_map_all`)
- [x] PHPStan passes with no new errors
- [x] Code formatted with php-cs-fixer

https://claude.ai/code/session_01DEA9oBhmVFqukmx6WEkL4G