### PR TITLE
Add documentation for map_all and flat_map_all

### DIFF
--- a/docs/api/functions.md
+++ b/docs/api/functions.md
@@ -410,6 +410,8 @@ Result\err($value);
 Result\fromThrowable($closure, $errorHandler);
 Result\flatten($result);
 Result\transpose($result);
+Result\map_all($fn, ...$results);
+Result\flat_map_all($fn, ...$results);
 Result\combine(...$results);
 ```
 
@@ -533,6 +535,78 @@ use EndouMame\PhpMonad\Option;
 Result\transpose(Result\ok(Option\some(42)));   // Some(Ok(42))
 Result\transpose(Result\ok(Option\none()));     // None
 Result\transpose(Result\err('error'));          // Some(Err('error'))
+```
+
+### map_all
+
+複数の Result がすべて Ok の場合にコールバックを適用し、結果を Ok で返します。1 つでも Err があれば最初の Err を返します。
+
+```php
+/**
+ * @template E
+ * @param Closure $fn
+ * @param Result<mixed, E> ...$results
+ * @return Result<mixed, E>
+ */
+function map_all(Closure $fn, Result ...$results): Result
+```
+
+#### 使用例
+
+```php
+// すべて Ok の場合、コールバックの結果が Ok で返される
+$result = Result\map_all(
+    fn(int $a, int $b, int $c) => $a + $b + $c,
+    Result\ok(1),
+    Result\ok(2),
+    Result\ok(3),
+);
+// Ok(6)
+
+// 1 つでも Err があれば最初の Err を返す
+$result = Result\map_all(
+    fn(int $a, int $b) => $a + $b,
+    Result\ok(1),
+    Result\err('エラー1'),
+    Result\err('エラー2'),
+);
+// Err('エラー1')
+```
+
+### flat_map_all
+
+複数の Result がすべて Ok の場合に Result を返すコールバックを適用します。1 つでも Err があれば最初の Err を返します。
+
+`map_all` との違いは、コールバック自体が Result を返す点です。
+
+```php
+/**
+ * @template E
+ * @param Closure $fn
+ * @param Result<mixed, E> ...$results
+ * @return Result<mixed, E>
+ */
+function flat_map_all(Closure $fn, Result ...$results): Result
+```
+
+#### 使用例
+
+```php
+// コールバックが Ok を返す場合
+$result = Result\flat_map_all(
+    fn(int $a, int $b) => Result\ok($a + $b),
+    Result\ok(1),
+    Result\ok(2),
+);
+// Ok(3)
+
+// コールバックが Err を返す場合
+$result = Result\flat_map_all(
+    fn(int $a, int $b) => Result\err('計算エラー'),
+    Result\ok(1),
+    Result\ok(2),
+);
+// Err('計算エラー')
 ```
 
 ### combine
@@ -764,7 +838,7 @@ Result\err('error') |> Result\expect('値が必要です');  // RuntimeException
 ```
 
 ::: tip バリデーションに便利
-`combine` はフォームバリデーションで特に便利です。
+`combine` はフォームバリデーションで全エラーを収集するのに便利です。
 
 ```php
 $result = Result\combine(
@@ -777,5 +851,16 @@ if ($result->isErr()) {
     $errors = $result->unwrapErr();
     // 全てのエラーメッセージを表示
 }
+```
+
+バリデーション結果から値を合成したい場合は `map_all` / `flat_map_all` を使います。
+
+```php
+$user = Result\map_all(
+    fn(string $email, string $password, int $age) => new User($email, $password, $age),
+    validateEmail($email),
+    validatePassword($password),
+    validateAge($age),
+);
 ```
 :::

--- a/docs/guide/result.md
+++ b/docs/guide/result.md
@@ -336,6 +336,45 @@ Result\transpose(Result\ok(Option\none()));     // None
 Result\transpose(Result\err('error'));          // Some(Err('error'))
 ```
 
+### map_all / flat_map_all
+
+複数の独立した Result を合成し、すべて Ok の場合にコールバックを適用します。関数型プログラミングにおける Applicative Functor パターンに相当します。
+
+```php
+use EndouMame\PhpMonad\Result;
+
+// map_all: コールバックの戻り値を Ok でラップ
+$title = TaskTitle::create($command->title);         // Result<TaskTitle, string>
+$description = TaskDescription::create($command->description);  // Result<TaskDescription, string>
+
+$task = Result\map_all(
+    fn(TaskTitle $t, TaskDescription $d) => new TaskDTO($t, $d),
+    $title,
+    $description,
+);
+// すべて Ok → Ok(TaskDTO)
+// どれか Err → 最初の Err を返す
+
+// flat_map_all: コールバック自体が Result を返す場合
+$task = Result\flat_map_all(
+    fn(TaskTitle $t, TaskDescription $d) => TodoTask::create($t, $d),
+    $title,
+    $description,
+);
+```
+
+`andThen` のネストが不要になり、独立した Result の合成がフラットに記述できます。
+
+::: tip combine との違い
+`combine` はすべてのエラーを収集しますが、成功時の値の合成手段を提供しません。`map_all` / `flat_map_all` は成功時に任意の関数を適用できます。
+
+| 関数 | 成功時 | 失敗時 |
+|------|--------|--------|
+| `map_all` | コールバックの結果を Ok でラップ | 最初の Err を返す |
+| `flat_map_all` | コールバックの Result をそのまま返す | 最初の Err を返す |
+| `combine` | `Ok(true)` を返す | 全エラーをリストで返す |
+:::
+
 ### combine
 
 複数の Result を検証し、全て成功なら Ok、1 つでも失敗なら全エラーを Err で返します。
@@ -481,7 +520,7 @@ function validateName(string $name): Result {
     return Result\ok($name);
 }
 
-// 複数のバリデーションを結合
+// 複数のバリデーションを結合（全エラーを収集）
 $result = Result\combine(
     validateAge($age),
     validateName($name)
@@ -491,6 +530,14 @@ if ($result->isErr()) {
     $errors = $result->unwrapErr();
     // ['年齢は 0 以上である必要があります', '名前は必須です']
 }
+
+// 複数のバリデーション結果から値を合成
+$user = Result\map_all(
+    fn(int $age, string $name) => new User($name, $age),
+    validateAge($age),
+    validateName($name),
+);
+// すべて Ok → Ok(User)、最初の Err で短絡
 ```
 
 ### エラーの変換


### PR DESCRIPTION
## Summary

- Add `map_all` / `flat_map_all` to the API reference (`docs/api/functions.md`) with signatures and usage examples
- Add guide section (`docs/guide/result.md`) with practical examples, `andThen` ネスト解消のモチベーション, and comparison table with `combine`
- Update validation pattern examples to show `map_all` as an alternative to `combine`
- textlint passes

## Test plan

- [x] textlint check passes
- [x] Documentation is consistent with implementation

https://claude.ai/code/session_01DEA9oBhmVFqukmx6WEkL4G