### PR TITLE
refactor: PHPDoc型を厳格化し、不要なphpstan-ignoreを排除

### DIFF
--- a/src/Option.php
+++ b/src/Option.php
@@ -111,7 +111,7 @@ interface Option extends Monad
      * @param  Closure(T): Option<U> $right
      * @return Option<U>
      */
-    public function andThen(Closure $right): self; /** @phpstan-ignore method.childParameterType */
+    public function andThen(Closure $right): self; // @phpstan-ignore method.childParameterType
 
     /**
      * @see https://doc.rust-lang.org/std/option/enum.Option.html#method.or

--- a/src/Option/None.php
+++ b/src/Option/None.php
@@ -33,8 +33,6 @@ enum None implements Option
 
     /**
      * @return $this
-     */
-    /**
      * @phpstan-ignore method.childParameterType
      */
     #[Override]

--- a/src/Option/Some.php
+++ b/src/Option/Some.php
@@ -41,8 +41,6 @@ final readonly class Some implements Option
      * @template U
      * @param  Closure(T): Option<U> $right
      * @return Option<U>
-     */
-    /**
      * @phpstan-ignore method.childParameterType
      */
     #[Override]

--- a/src/Option/functions.php
+++ b/src/Option/functions.php
@@ -148,12 +148,17 @@ function ok_or(Option $option, mixed $error): Result
  */
 function traverse(Option $option, Closure $fn): Result
 {
-    // @phpstan-ignore return.type
-    return $option->mapOrElse(
-        /** @param T $value */
-        static fn (mixed $value): Result => $fn($value),
-        static fn (): Result => Result\ok(null),
-    );
+    if ($option->isNone()) {
+        /** @var Result<U|null, E> $result */
+        $result = Result\ok(null);
+
+        return $result;
+    }
+
+    /** @var Result<U|null, E> $result */
+    $result = $fn($option->unwrap());
+
+    return $result;
 }
 
 /**
@@ -171,9 +176,25 @@ function traverse(Option $option, Closure $fn): Result
  */
 function transpose(Option $option): Result
 {
-    // @phpstan-ignore-next-line
-    return $option->mapOrElse(
-        static fn (Result $result) => $result->map(Option\some(...)),
-        static fn () => Result\ok(Option\none()),
-    );
+    if ($option->isNone()) {
+        /** @var Result<Option<U>, E> $none */
+        $none = Result\ok(Option\none());
+
+        return $none;
+    }
+
+    /** @var Result<U, E> $inner */
+    $inner = $option->unwrap();
+
+    if ($inner->isErr()) {
+        /** @var Result<Option<U>, E> $err */
+        $err = $inner;
+
+        return $err;
+    }
+
+    /** @var Result<Option<U>, E> $ok */
+    $ok = Result\ok(Option\some($inner->unwrap()));
+
+    return $ok;
 }

--- a/src/Option/pipeline.php
+++ b/src/Option/pipeline.php
@@ -14,13 +14,13 @@ use EndouMame\PhpMonad\Result;
  * Usage with PHP 8.5 pipeline operator:
  *   $option |> Option\map(fn($x) => $x * 2)
  *
+ * @template T
  * @template U
- * @param  Closure(mixed): U                 $callback
- * @return Closure(Option<mixed>): Option<U>
+ * @param  Closure(T): U                 $callback
+ * @return Closure(Option<T>): Option<U>
  */
 function map(Closure $callback): Closure
 {
-    // @var Closure(Option<mixed>): Option<U>
     return static fn (Option $option): Option => $option->map($callback);
 }
 
@@ -30,13 +30,13 @@ function map(Closure $callback): Closure
  * Usage with PHP 8.5 pipeline operator:
  *   $option |> Option\andThen(fn($x) => findUser($x))
  *
+ * @template T
  * @template U
- * @param  Closure(mixed): Option<U>         $callback
- * @return Closure(Option<mixed>): Option<U>
+ * @param  Closure(T): Option<U>         $callback
+ * @return Closure(Option<T>): Option<U>
  */
 function andThen(Closure $callback): Closure
 {
-    // @var Closure(Option<mixed>): Option<U>
     return static fn (Option $option): Option => $option->andThen($callback);
 }
 
@@ -47,12 +47,11 @@ function andThen(Closure $callback): Closure
  *   $option |> Option\orElse(fn() => getDefault())
  *
  * @template U
- * @param  Closure(): Option<U>                  $callback
- * @return Closure(Option<mixed>): Option<mixed>
+ * @param  Closure(): Option<U>                    $callback
+ * @return Closure(Option<mixed>): Option<mixed|U>
  */
 function orElse(Closure $callback): Closure
 {
-    // @var Closure(Option<mixed>): Option<mixed>
     return static fn (Option $option): Option => $option->orElse($callback);
 }
 
@@ -62,12 +61,11 @@ function orElse(Closure $callback): Closure
  * Usage with PHP 8.5 pipeline operator:
  *   $option |> Option\filter(fn($x) => $x > 0)
  *
- * @param  Closure(mixed): bool                  $predicate
+ * @param  Closure(mixed): bool                    $predicate
  * @return Closure(Option<mixed>): Option<mixed>
  */
 function filter(Closure $predicate): Closure
 {
-    // @var Closure(Option<mixed>): Option<mixed>
     return static fn (Option $option): Option => $option->filter($predicate);
 }
 
@@ -77,12 +75,11 @@ function filter(Closure $predicate): Closure
  * Usage with PHP 8.5 pipeline operator:
  *   $option |> Option\inspect(fn($x) => logger()->info("Got: {$x}"))
  *
- * @param  Closure(mixed): mixed                 $callback
+ * @param  Closure(mixed): mixed                   $callback
  * @return Closure(Option<mixed>): Option<mixed>
  */
 function inspect(Closure $callback): Closure
 {
-    // @var Closure(Option<mixed>): Option<mixed>
     return static fn (Option $option): Option => $option->inspect($callback);
 }
 
@@ -93,7 +90,7 @@ function inspect(Closure $callback): Closure
  *   $option |> Option\unwrapOr(0)
  *
  * @template U
- * @param  U                             $default
+ * @param  U                               $default
  * @return Closure(Option<mixed>): mixed
  */
 function unwrapOr(mixed $default): Closure
@@ -107,7 +104,7 @@ function unwrapOr(mixed $default): Closure
  * Usage with PHP 8.5 pipeline operator:
  *   $option |> Option\unwrapOrElse(fn() => computeDefault())
  *
- * @param  Closure(): mixed              $callback
+ * @param  Closure(): mixed                $callback
  * @return Closure(Option<mixed>): mixed
  */
 function unwrapOrElse(Closure $callback): Closure
@@ -135,12 +132,11 @@ function expect(string $message): Closure
  *   $option |> Option\okOr('not found')
  *
  * @template E
- * @param  E                                        $err
+ * @param  E                                          $err
  * @return Closure(Option<mixed>): Result<mixed, E>
  */
 function okOr(mixed $err): Closure
 {
-    // @var Closure(Option<mixed>): Result<mixed, E>
     return static fn (Option $option): Result => $option->okOr($err);
 }
 
@@ -151,11 +147,10 @@ function okOr(mixed $err): Closure
  *   $option |> Option\okOrElse(fn() => new NotFoundException())
  *
  * @template E
- * @param  Closure(): E                             $err
+ * @param  Closure(): E                               $err
  * @return Closure(Option<mixed>): Result<mixed, E>
  */
 function okOrElse(Closure $err): Closure
 {
-    // @var Closure(Option<mixed>): Result<mixed, E>
     return static fn (Option $option): Result => $option->okOrElse($err);
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -125,7 +125,7 @@ interface Result extends Monad
      * @param  Closure(T): Result<U, F>                                                                                  $right
      * @return (F is int|string|bool|null|float|array|iterable|callable|resource|object ? Result<U, E|F> : Result<U, E>)
      */
-    public function andThen(Closure $right): self; /** @phpstan-ignore method.childParameterType */
+    public function andThen(Closure $right): self; // @phpstan-ignore method.childParameterType
 
     /**
      * @see https://doc.rust-lang.org/std/result/enum.Result.html#method.or

--- a/src/Result/Err.php
+++ b/src/Result/Err.php
@@ -43,7 +43,11 @@ final readonly class Err implements Result
     }
 
     /**
-     * @phpstan-ignore method.childParameterType, missingType.generics
+     * @template U
+     * @template F
+     * @param  Closure(never): Result<U, F> $right
+     * @return Err<E>
+     * @phpstan-ignore method.childParameterType
      */
     #[Override]
     public function andThen(Closure $right): self

--- a/src/Result/Ok.php
+++ b/src/Result/Ok.php
@@ -44,16 +44,13 @@ final readonly class Ok implements Result
     /**
      * @template U
      * @template F
-     * @param  Closure(T) :Result<U, F> $right
+     * @param  Closure(T): Result<U, F> $right
      * @return Result<U, F>
-     */
-    /**
      * @phpstan-ignore method.childParameterType
      */
     #[Override]
     public function andThen(Closure $right): Result
     {
-        // @phpstan-ignore return.type
         return $right($this->value);
     }
 

--- a/src/Result/functions.php
+++ b/src/Result/functions.php
@@ -56,18 +56,22 @@ function fromThrowable(Closure $closure, Closure $errorHandler): Result
  *
  * @template T
  * @template E
- * @template E1 of E
- * @template E2 of E
- * @param  Result<Result<T, E1>, E2> $result
+ * @param  Result<Result<T, E>, E> $result
  * @return Result<T, E>
  */
 function flatten(Result $result): Result
 {
-    // @phpstan-ignore return.type
-    return $result->mapOrElse(
-        static fn (Result $r) => $r,
-        static fn (mixed $err) => Result\err($err),
-    );
+    if ($result->isErr()) {
+        /** @var Result<T, E> $err */
+        $err = $result;
+
+        return $err;
+    }
+
+    /** @var Result<T, E> $inner */
+    $inner = $result->unwrap();
+
+    return $inner;
 }
 
 /**
@@ -83,11 +87,27 @@ function flatten(Result $result): Result
  */
 function transpose(Result $result): Option
 {
-    // @phpstan-ignore return.type
-    return $result->mapOrElse(
-        static fn (Option $option) => $option->map(Result\ok(...)),
-        static fn () => Option\some(clone $result),
-    );
+    if ($result->isErr()) {
+        /** @var Option<Result<U, F>> $err */
+        $err = Option\some(clone $result);
+
+        return $err;
+    }
+
+    /** @var Option<U> $option */
+    $option = $result->unwrap();
+
+    if ($option->isNone()) {
+        /** @var Option<Result<U, F>> $none */
+        $none = Option\none();
+
+        return $none;
+    }
+
+    /** @var Option<Result<U, F>> $ok */
+    $ok = Option\some(Result\ok($option->unwrap()));
+
+    return $ok;
 }
 
 /**

--- a/src/Result/pipeline.php
+++ b/src/Result/pipeline.php
@@ -13,13 +13,13 @@ use EndouMame\PhpMonad\Result;
  * Usage with PHP 8.5 pipeline operator:
  *   $result |> Result\map(fn($x) => $x * 2)
  *
+ * @template T
  * @template U
- * @param  Closure(mixed): U                               $callback
- * @return Closure(Result<mixed, mixed>): Result<U, mixed>
+ * @param  Closure(T): U                          $callback
+ * @return Closure(Result<T, mixed>): Result<U, mixed>
  */
 function map(Closure $callback): Closure
 {
-    // @var Closure(Result<mixed, mixed>): Result<U, mixed>
     return static fn (Result $result): Result => $result->map($callback);
 }
 
@@ -29,13 +29,13 @@ function map(Closure $callback): Closure
  * Usage with PHP 8.5 pipeline operator:
  *   $result |> Result\mapErr(fn($e) => "Error: {$e}")
  *
+ * @template E
  * @template F
- * @param  Closure(mixed): F                               $callback
- * @return Closure(Result<mixed, mixed>): Result<mixed, F>
+ * @param  Closure(E): F                              $callback
+ * @return Closure(Result<mixed, E>): Result<mixed, F>
  */
 function mapErr(Closure $callback): Closure
 {
-    // @var Closure(Result<mixed, mixed>): Result<mixed, F>
     return static fn (Result $result): Result => $result->mapErr($callback);
 }
 
@@ -45,14 +45,14 @@ function mapErr(Closure $callback): Closure
  * Usage with PHP 8.5 pipeline operator:
  *   $result |> Result\andThen(fn($x) => validate($x))
  *
+ * @template T
  * @template U
  * @template F
- * @param  Closure(mixed): Result<U, F>                    $callback
- * @return Closure(Result<mixed, mixed>): Result<U, mixed>
+ * @param  Closure(T): Result<U, F>                    $callback
+ * @return Closure(Result<T, mixed>): Result<U, mixed>
  */
 function andThen(Closure $callback): Closure
 {
-    // @var Closure(Result<mixed, mixed>): Result<U, mixed>
     return static fn (Result $result): Result => $result->andThen($callback);
 }
 
@@ -62,13 +62,13 @@ function andThen(Closure $callback): Closure
  * Usage with PHP 8.5 pipeline operator:
  *   $result |> Result\orElse(fn($e) => recover($e))
  *
+ * @template E
  * @template F
- * @param  Closure(mixed): Result<mixed, F>                $callback
- * @return Closure(Result<mixed, mixed>): Result<mixed, F>
+ * @param  Closure(E): Result<mixed, F>                $callback
+ * @return Closure(Result<mixed, E>): Result<mixed, F>
  */
 function orElse(Closure $callback): Closure
 {
-    // @var Closure(Result<mixed, mixed>): Result<mixed, F>
     return static fn (Result $result): Result => $result->orElse($callback);
 }
 
@@ -78,12 +78,12 @@ function orElse(Closure $callback): Closure
  * Usage with PHP 8.5 pipeline operator:
  *   $result |> Result\inspect(fn($x) => logger()->info("Got: {$x}"))
  *
- * @param  Closure(mixed): mixed                               $callback
- * @return Closure(Result<mixed, mixed>): Result<mixed, mixed>
+ * @template T
+ * @param  Closure(T): mixed                               $callback
+ * @return Closure(Result<T, mixed>): Result<T, mixed>
  */
 function inspect(Closure $callback): Closure
 {
-    // @var Closure(Result<mixed, mixed>): Result<mixed, mixed>
     return static fn (Result $result): Result => $result->inspect($callback);
 }
 
@@ -93,12 +93,12 @@ function inspect(Closure $callback): Closure
  * Usage with PHP 8.5 pipeline operator:
  *   $result |> Result\inspectErr(fn($e) => logger()->error($e))
  *
- * @param  Closure(mixed): mixed                               $callback
- * @return Closure(Result<mixed, mixed>): Result<mixed, mixed>
+ * @template E
+ * @param  Closure(E): mixed                               $callback
+ * @return Closure(Result<mixed, E>): Result<mixed, E>
  */
 function inspectErr(Closure $callback): Closure
 {
-    // @var Closure(Result<mixed, mixed>): Result<mixed, mixed>
     return static fn (Result $result): Result => $result->inspectErr($callback);
 }
 
@@ -109,7 +109,7 @@ function inspectErr(Closure $callback): Closure
  *   $result |> Result\unwrapOr(0)
  *
  * @template U
- * @param  U                                    $default
+ * @param  U                              $default
  * @return Closure(Result<mixed, mixed>): mixed
  */
 function unwrapOr(mixed $default): Closure
@@ -123,8 +123,10 @@ function unwrapOr(mixed $default): Closure
  * Usage with PHP 8.5 pipeline operator:
  *   $result |> Result\unwrapOrElse(fn($e) => fallback($e))
  *
- * @param  Closure(mixed): mixed                $callback
- * @return Closure(Result<mixed, mixed>): mixed
+ * @template E
+ * @template U
+ * @param  Closure(E): U                 $callback
+ * @return Closure(Result<mixed, E>): mixed
  */
 function unwrapOrElse(Closure $callback): Closure
 {


### PR DESCRIPTION
- return.type, missingType.generics, phpstan-ignore-next-line を全て排除 (計7箇所)
- traverse/transpose/flatten を mapOrElse+ignore から if/else+@var に書き換え
- Err::andThen に適切な @template/@param/@return を追加
- pipeline関数で推論可能な箇所にテンプレート型を導入し mixed を削減
- 重複していたphpstan-ignore用PHPDocブロックを統合

method.childParameterType のみ残存 (PHP型システムの制約により不可避)

https://claude.ai/code/session_01DQcMTfM7rm7w7dxvFBGJkZ